### PR TITLE
Fix typo in smokeTest

### DIFF
--- a/cypress/e2e/smokeTest/smokeTest.cy.js
+++ b/cypress/e2e/smokeTest/smokeTest.cy.js
@@ -64,7 +64,7 @@ describe('Smoke Test Suite', () => {
         searchResultsPage.getBookingConfirmation().should('contain.text', 'is confirmed');
 
     });
-    it('should see the trasnfer and cancel it', () => {
+    it('should see the transfer and cancel it', () => {
         myTransfersPage.clickOnMyTransfersButton();
         myTransfersPage.getMyTransfersBody().should('contain.text', 'My transfers');
         myTransfersPage.clickOnTransferDialog();


### PR DESCRIPTION
## Summary
- correct spelling of `transfer` in smokeTest

## Testing
- `npm run test-all` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841842c7434833397c0c1c2a15dfd68